### PR TITLE
Updated image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository provides example manifests file you can use to deploy this. Thes
 We also provide a Helm chart in our [Charts repository](https://github.com/src-d/charts). 
 ```bash
 ~ $ helm repo add srcd-infra https://src-d.github.io/charts/infra/
-~ $ helm install k8s-pod-headless-service-operator --set image.tag=v1.0.0
+~ $ helm install k8s-pod-headless-service-operator --set image.tag=v0.1.1
 ```
 
 # Configuration


### PR DESCRIPTION
Currently there is no such tag as `v1.0.0`. 

See: https://hub.docker.com/r/srcd/k8s-pod-headless-service-operator/tags